### PR TITLE
fix: Move EVS signing to afterPack to enable DRM support on macOS

### DIFF
--- a/build/entitlements.mac.inherit.plist
+++ b/build/entitlements.mac.inherit.plist
@@ -6,6 +6,10 @@
     <true/>
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
     <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
     <key>com.apple.security.cs.debugger</key>
     <true/>
     <key>com.apple.security.device.audio-input</key>

--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -6,6 +6,10 @@
     <true/>
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
     <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
     <key>com.apple.security.cs.debugger</key>
     <true/>
     <key>com.apple.security.device.audio-input</key>

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -14,6 +14,7 @@ module.exports = {
   directories: {
     output: "release"
   },
+  afterPack: "scripts/evs-sign.js",
   mac: {
     target: ["dmg"],
     category: "public.app-category.education",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "build": "tsc",
     "start": "npm run build && electron .",
     "dist": "npm run build && electron-builder",
-    "dist:mac": "npm run build && electron-builder --config electron-builder.config.cjs --mac --universal",
+    "dist:mac-arm": "npm run build && electron-builder --config electron-builder.config.cjs --mac --arm64",
+    "dist:mac-x64": "npm run build && electron-builder --config electron-builder.config.cjs --mac --x64",
     "dist:win": "npm run build && electron-builder --config electron-builder.config.cjs --win --x64",
     "dist:mas": "npm run build && electron-builder --config electron-builder.config.cjs --mac mas --universal",
     "dist:mas-dev": "npm run build && electron-builder --config electron-builder.config.cjs --mac mas-dev --universal"

--- a/scripts/evs-sign.js
+++ b/scripts/evs-sign.js
@@ -1,0 +1,18 @@
+import { execSync } from 'child_process';
+
+const _default = async function (context) {
+    const { electronPlatformName, appOutDir } = context;
+    if (electronPlatformName === 'darwin') {
+        console.log('Signing with EVS for macOS...');
+        try {
+            execSync(`python3 -m castlabs_evs.vmp sign-pkg "${appOutDir}"`, {
+                stdio: 'inherit'
+            });
+            console.log('EVS signing completed successfully');
+        } catch (error) {
+            console.error('EVS signing failed:', error);
+            throw error;
+        }
+    }
+};
+export { _default as default };


### PR DESCRIPTION
- Fixed an issue where DRM-protected videos were not playing on macOS builds.
- The issue occurred because the EVS (CastLabs) signing was previously triggered before the Electron build process, which caused the signature to become invalid after packaging.
- Moved EVS signing logic to afterPack in `electron-builder.config.cjs` so the signing happens after packaging but before final artifact creation, ensuring the final app is properly signed.
- Updated entitlements.mac.plist to allow required capabilities.
- Separated macOS build commands into dist:mac-arm and dist:mac-x64 for platform-specific builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced media playback capabilities by enabling Widevine CDM and allowing autoplay without user gestures.
	- Added support for browser plugins within the application.

- **Chores**
	- Updated build process to include a post-packaging signing step for macOS builds.
	- Modified build scripts to explicitly target specific CPU architectures for macOS and Windows.
	- Switched Electron dependency to a customized version from castlabs with a new download source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->