### PR TITLE
fix: Prevent screen recording in child windows

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -46,6 +46,12 @@ function createWindow() {
 
 app.whenReady().then(createWindow);
 
+app.on('web-contents-created', (_event, contents) => {
+  contents.on('did-create-window', (childWindow) => {
+    childWindow.setContentProtection(true);
+  });
+});
+
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') app.quit();
 });


### PR DESCRIPTION
- Previously, setContentProtection(true) was only applied to the main window.
- As a result, any child windows created (e.g., pop-ups, modals) were not protected, allowing potential screen recording or screen capture.
- This commit fixes the issue by listening to the did-create-window event inside the web-contents-created handler.
- Now, all child windows automatically inherit setContentProtection(true), ensuring consistent protection across the app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Content protection is now automatically enabled for all new child windows, enhancing privacy and security throughout the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->