### PR TITLE
feat: Implement window open handler for child windows

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -45,16 +45,31 @@ function createWindow() {
   const baseUA = mainWindow.webContents.getUserAgent();
   mainWindow.webContents.setUserAgent(`${baseUA} Testpress Desktop Application`);
 
+  mainWindow.webContents.setWindowOpenHandler(({ url, features }) => {
+    const childWindow = new BrowserWindow({
+      parent: mainWindow,
+      modal: false,
+      show: true,
+      webPreferences: {
+        nodeIntegration: false,
+        sandbox: false,
+        contextIsolation: true,
+        webSecurity: true,
+        plugins: true,
+        devTools: false,
+      },
+    });
+    childWindow.setContentProtection(true);
+    const childBaseUA = childWindow.webContents.getUserAgent();
+    childWindow.webContents.setUserAgent(`${childBaseUA} Testpress Desktop Application`);
+    childWindow.loadURL(url);
+    return { action: 'deny' };
+  });
+
   mainWindow.loadURL(appConfig.homepageURL);
 }
 
 app.whenReady().then(createWindow);
-
-app.on('web-contents-created', (_event, contents) => {
-  contents.on('did-create-window', (childWindow) => {
-    childWindow.setContentProtection(true);
-  });
-});
 
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') app.quit();


### PR DESCRIPTION
- Add a handler to manage the creation of child windows, ensuring they inherit the user agent and have content protection enabled.
- Remove the previous event listener for 'web-contents-created' as it is no longer needed.