### PR TITLE
feat: Add support for APPX targets

### DIFF
--- a/app-config.json
+++ b/app-config.json
@@ -1,11 +1,13 @@
 {
-  "productName": "Testpress",
+  "productName": "Testpress LMS",
   "homepageURL": "https://lmsdemo.testpress.in/",
-  "appId": "in.testpress.lmsdemo.desktop",
+  "appId": "TestpressTechLabs.TestpressLMS",
   "macAppStoreId": "6745862112",
-  "windowsStoreId": "9WZDNCRFJ3Q8",
+  "windowsStoreId": "9PK57X3TM0N2",
   "author": "Testpress",
   "description": "Testpress Desktop Application",
   "provisioningProfile": "lmsdemoDistributionprovisionprofile.provisionprofile",
-  "identity": "Testpress Tech Labs LLP (BHAB7LC35Y)"
+  "identity": "Testpress Tech Labs LLP (BHAB7LC35Y)",
+  "publisherId": "27270D5F-9226-4A37-BF69-03BF0033FD28",
+  "publisherDisplayName": "Testpress Tech Labs"
 }

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -39,8 +39,23 @@ module.exports = {
     type: "development"
   },
   win: {
-    target: ["nsis"],
+    target: [
+      {
+        target: "nsis",
+        arch: ["x64"]
+      },
+      {
+        target: "appx",
+        arch: ["x64"]
+      }
+    ],
     icon: "assets/icon.ico"
+  },
+  appx: {
+    identityName: config.appId,
+    publisher: config.publisherId,
+    publisherDisplayName: config.publisherDisplayName,
+    displayName: config.productName,
   },
   nsis: {
     oneClick: true,

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "dist:mac-arm": "npm run build && electron-builder --config electron-builder.config.cjs --mac --arm64",
     "dist:mac-x64": "npm run build && electron-builder --config electron-builder.config.cjs --mac --x64",
     "dist:win": "npm run build && electron-builder --config electron-builder.config.cjs --win --x64",
+    "dist:msix": "npm run build && electron-builder --config electron-builder.config.cjs --win appx --x64",
     "dist:mas": "npm run build && electron-builder --config electron-builder.config.cjs --mac mas --universal",
     "dist:mas-dev": "npm run build && electron-builder --config electron-builder.config.cjs --mac mas-dev --universal"
   },


### PR DESCRIPTION
- Modify electron-builder configuration to support both NSIS and APPX targets for Windows.
- Introduce new build script for MSIX packaging in package.json.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Windows MSIX (Appx) packaging, enabling installation via the Windows Store.
  * Introduced a new build script to generate MSIX packages for Windows.

* **Chores**
  * Updated branding and store identifiers, including product name and publisher details, across configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->