### PR TITLE
fix: Publishing error due to incorrect publisherId

### DIFF
--- a/app-config.json
+++ b/app-config.json
@@ -11,3 +11,4 @@
   "publisherId": "CN=27270D5F-9226-4A37-BF69-03BF0033FD28",
   "publisherDisplayName": "Testpress Tech Labs"
 }
+

--- a/app-config.json
+++ b/app-config.json
@@ -8,6 +8,6 @@
   "description": "Testpress Desktop Application",
   "provisioningProfile": "lmsdemoDistributionprovisionprofile.provisionprofile",
   "identity": "Testpress Tech Labs LLP (BHAB7LC35Y)",
-  "publisherId": "27270D5F-9226-4A37-BF69-03BF0033FD28",
+  "publisherId": "CN=27270D5F-9226-4A37-BF69-03BF0033FD28",
   "publisherDisplayName": "Testpress Tech Labs"
 }

--- a/app-config.json
+++ b/app-config.json
@@ -11,4 +11,3 @@
   "publisherId": "CN=27270D5F-9226-4A37-BF69-03BF0033FD28",
   "publisherDisplayName": "Testpress Tech Labs"
 }
-


### PR DESCRIPTION
- Microsoft Store submission failed because the publisherId was incorrectly set,
  causing the package validation to reject the build.
- This happened because the publisherId in the configuration did not match the
  required CN= format for Microsoft Store publishing.
- Fixed by updating the publisherId to the correct CN format to allow successful submission.
