### PR TITLE
fix: Allow Google login URLs to open in new window

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -38,6 +38,7 @@ function setCustomUserAgent(webContents: Electron.WebContents) {
   webContents.setUserAgent(`${baseUA} Testpress Desktop Application`);
 }
 
+const GOOGLE_LOGIN_URL_PREFIX = 'https://accounts.google.com/';
 function createWindow() {
   mainWindow = new BrowserWindow(windowOptions);
   mainWindow.setContentProtection(true);
@@ -52,12 +53,11 @@ function createWindow() {
   });
 
   setCustomUserAgent(mainWindow.webContents);
-  const GOOGLE_LOGIN_URL_PREFIX = 'https://accounts.google.com/';
 
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-  if (url.startsWith(GOOGLE_LOGIN_URL_PREFIX)) {
-    return { action: 'allow' };
-  }
+    if (url.startsWith(GOOGLE_LOGIN_URL_PREFIX)) {
+      return { action: 'allow' };
+    }
     const childWindow = new BrowserWindow({
       ...windowOptions,
       parent: mainWindow,

--- a/src/main.ts
+++ b/src/main.ts
@@ -52,8 +52,12 @@ function createWindow() {
   });
 
   setCustomUserAgent(mainWindow.webContents);
+  const GOOGLE_LOGIN_URL_PREFIX = 'https://accounts.google.com/';
 
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+  if (url.startsWith(GOOGLE_LOGIN_URL_PREFIX)) {
+    return { action: 'allow' };
+  }
     const childWindow = new BrowserWindow({
       ...windowOptions,
       parent: mainWindow,


### PR DESCRIPTION
- Updated setWindowOpenHandler to allow URLs starting with https://accounts.google.com/.

- Google login flow will now open normally in a separate window.

- Other URLs still open in a custom child window with content protection enabled.