### PR TITLE
ci: Configure Apple API credentials for DMG notarization

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,6 @@ on:
         description: 'Comma-separated domain URLs (e.g., demo.testpress.in, lmsdemo.testpress.in)'
         required: true
         type: string
-        default: lmsdemo.testpress.in
       build_target:
         description: 'Build target'
         required: true
@@ -17,8 +16,7 @@ on:
           - windows-exe
           - mac-dmg
           - windows-appx
-        default: mac-dmg
-  pull_request:
+        default: all
 
 jobs:
   parse:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,8 @@ on:
           - windows-exe
           - mac-dmg
           - windows-appx
-        default: all
+        default: mac-dmg
+  pull_request:
 
 jobs:
   parse:
@@ -100,6 +101,16 @@ jobs:
         run: npm run dist:appx
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Apple API Key
+        if: steps.check_os.outputs.run == 'true' && matrix.os == 'macos-latest'
+        shell: bash
+        run: |
+          echo "${{ secrets.APPLE_API_KEY_BASE64 }}" | base64 --decode > AuthKey_JWX97Q39TN.p8
+
+          echo "APPLE_API_KEY=$PWD/AuthKey_JWX97Q39TN.p8" >> $GITHUB_ENV
+          echo "APPLE_API_KEY_ID=${{ secrets.APPLE_API_KEY_ID }}" >> $GITHUB_ENV
+          echo "APPLE_API_ISSUER=${{ secrets.APPLE_API_ISSUER }}" >> $GITHUB_ENV
 
       - name: Build and Package (macOS DMG)
         if: steps.check_os.outputs.run == 'true' && matrix.os == 'macos-latest' && (github.event.inputs.build_target == 'all' || github.event.inputs.build_target == 'mac-dmg')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,6 +101,21 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install macOS signing certificate
+        if: steps.check_os.outputs.run == 'true' && matrix.os == 'macos-latest'
+        env:
+          MACOS_CERT_P12_BASE64: ${{ secrets.MACOS_CERT_P12_BASE64 }}
+          MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
+        run: |
+          echo "$MACOS_CERT_P12_BASE64" | base64 --decode > cert.p12
+          security create-keychain -p "" build.keychain
+          security set-keychain-settings -lut 21600 build.keychain
+          security unlock-keychain -p "" build.keychain
+          security import cert.p12 -k build.keychain -P "$MACOS_CERT_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "" build.keychain
+          security list-keychains -d user -s build.keychain login.keychain-db
+          security default-keychain -s build.keychain
+
       - name: Setup Apple API Key
         if: steps.check_os.outputs.run == 'true' && matrix.os == 'macos-latest'
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
         description: 'Comma-separated domain URLs (e.g., demo.testpress.in, lmsdemo.testpress.in)'
         required: true
         type: string
+        default: lmsdemo.testpress.in
       build_target:
         description: 'Build target'
         required: true


### PR DESCRIPTION
- macOS DMG builds were not notarized, causing users to hit security warnings and preventing the app from opening normally.
- The app was not being signed/notarized with our Apple developer credentials, so Apple Gatekeeper did not recognize the build as trusted.
- Added Apple API credentials via GitHub Secrets and updated the workflow to generate the .p8 key at build time, enabling automated DMG notarization during CI.