### PR TITLE
fix: Child windows not opening for non-exam popups

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -83,26 +83,20 @@ function createWindow() {
       return { action: 'allow' };
     }
     
-    const isExamWindow = url.includes('/exams/');
-    if (isExamWindow) {
-      return {
-        action: 'allow',
-        overrideBrowserWindowOptions: {
-          ...windowOptions,
-          parent: mainWindow,
-          modal: false,
-          show: true,
-        },
-      };
-    }
-    return { action: 'deny' };
+    return {
+      action: 'allow',
+      overrideBrowserWindowOptions: {
+        ...windowOptions,
+        parent: mainWindow,
+        modal: false,
+        show: true,
+      },
+    };
   });
 
   mainWindow.webContents.on('did-create-window', (childWindow, details) => {
-    if (details.url.includes('/exams/')) {
       childWindow.setContentProtection(true);
       setCustomUserAgent(childWindow.webContents);
-    }
   });
 
   mainWindow.loadURL(appConfig.homepageURL);

--- a/src/main.ts
+++ b/src/main.ts
@@ -96,7 +96,9 @@ function createWindow() {
 
   mainWindow.webContents.on('did-create-window', (childWindow, details) => {
       childWindow.setContentProtection(true);
-      setCustomUserAgent(childWindow.webContents);
+      if (!details.url.startsWith(GOOGLE_LOGIN_URL_PREFIX)) {
+        setCustomUserAgent(childWindow.webContents);
+      }
   });
 
   mainWindow.loadURL(appConfig.homepageURL);


### PR DESCRIPTION
### Description
Child windows were not opening for features such as live classes in the Electron app. This was caused by a commit introduced in #18  where pop-up windows were restricted to exam URLs and all other pop-up requests were denied.

This change restores pop-up support for non-exam flows while continuing to apply the required window configuration and security settings to child windows.