### PR TITLE
fix: Apply custom desktop user-agent for child windows

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const appConfigPath = join(__dirname, '..', 'app-config.json');
 const appConfig = JSON.parse(readFileSync(appConfigPath, 'utf8'));
+const CUSTOM_USER_AGENT = 'Testpress Desktop Application';
 
 electronUnhandled({
   showDialog: true,
@@ -36,8 +37,8 @@ const windowOptions = {
 
 function setCustomUserAgent(webContents: Electron.WebContents) {
   const baseUA = webContents.getUserAgent();
-  if (!baseUA.includes('Testpress Desktop Application')) {
-    webContents.setUserAgent(`${baseUA} Testpress Desktop Application`);
+  if (!baseUA.includes(CUSTOM_USER_AGENT)) {
+    webContents.setUserAgent(`${baseUA} ${CUSTOM_USER_AGENT}`);
   }
 }
 
@@ -56,8 +57,8 @@ function setupDeviceHeaders(webContents: Electron.WebContents) {
 
         const uaKey = Object.keys(details.requestHeaders).find(key => key.toLowerCase() === 'user-agent') || 'User-Agent';
         const userAgent = details.requestHeaders[uaKey];
-        if (userAgent && !userAgent.includes('Testpress Desktop Application')) {
-          details.requestHeaders[uaKey] = `${userAgent} Testpress Desktop Application`;
+        if (userAgent && !userAgent.includes(CUSTOM_USER_AGENT)) {
+          details.requestHeaders[uaKey] = `${userAgent} ${CUSTOM_USER_AGENT}`;
         }
       }
     }
@@ -92,7 +93,7 @@ function createWindow() {
     }
 
     const baseUA = mainWindow.webContents.getUserAgent();
-    const customUA = baseUA.includes('Testpress Desktop Application') ? baseUA : `${baseUA} Testpress Desktop Application`;
+    const customUA = baseUA.includes(CUSTOM_USER_AGENT) ? baseUA : `${baseUA} ${CUSTOM_USER_AGENT}`;
     
     return {
       action: 'allow',

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,7 +36,9 @@ const windowOptions = {
 
 function setCustomUserAgent(webContents: Electron.WebContents) {
   const baseUA = webContents.getUserAgent();
-  webContents.setUserAgent(`${baseUA} Testpress Desktop Application`);
+  if (!baseUA.includes('Testpress Desktop Application')) {
+    webContents.setUserAgent(`${baseUA} Testpress Desktop Application`);
+  }
 }
 
 function setupDeviceHeaders(webContents: Electron.WebContents) {
@@ -51,6 +53,12 @@ function setupDeviceHeaders(webContents: Electron.WebContents) {
       if (requestUrl.origin === allowedOrigin) {
         details.requestHeaders['X-Device-UID'] = deviceUid;
         details.requestHeaders['X-Device-Type'] = deviceType;
+
+        const uaKey = Object.keys(details.requestHeaders).find(key => key.toLowerCase() === 'user-agent') || 'User-Agent';
+        const userAgent = details.requestHeaders[uaKey];
+        if (userAgent && !userAgent.includes('Testpress Desktop Application')) {
+          details.requestHeaders[uaKey] = `${userAgent} Testpress Desktop Application`;
+        }
       }
     }
     catch (error) {
@@ -82,6 +90,9 @@ function createWindow() {
     if (url.startsWith(GOOGLE_LOGIN_URL_PREFIX)) {
       return { action: 'allow' };
     }
+
+    const baseUA = mainWindow.webContents.getUserAgent();
+    const customUA = baseUA.includes('Testpress Desktop Application') ? baseUA : `${baseUA} Testpress Desktop Application`;
     
     return {
       action: 'allow',
@@ -90,6 +101,10 @@ function createWindow() {
         parent: mainWindow,
         modal: false,
         show: true,
+        webPreferences: {
+          ...windowOptions.webPreferences,
+          userAgent: customUA,
+        },
       },
     };
   });


### PR DESCRIPTION

### Issue
- Exam content opened in child windows was failing with a `device_restricted` 403 error because the initial API requests were sent before the custom desktop user agent was applied.
- The `did-create-window` event executes after child window creation, causing early requests to use the default Electron user agent.

### Fix
- Applied the custom user agent when creating child windows to ensure exam requests are identified as coming from the desktop application.
- Ensured backend API requests from child windows include the desktop application identifier, avoiding `device_restricted` errors caused by missing user-agent detection.

Todo - https://3.basecamp.com/4160028/buckets/47506127/card_tables/cards/10001283539