### PR TITLE
fix: Ensure child windows use the custom user agent

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow } from 'electron';
+import { app, BrowserWindow, session } from 'electron';
 import electronUnhandled from 'electron-unhandled';
 import { readFileSync } from 'fs';
 import { join } from 'path';
@@ -92,9 +92,6 @@ function createWindow() {
       return { action: 'allow' };
     }
 
-    const baseUA = mainWindow.webContents.getUserAgent();
-    const customUA = baseUA.includes(CUSTOM_USER_AGENT) ? baseUA : `${baseUA} ${CUSTOM_USER_AGENT}`;
-    
     return {
       action: 'allow',
       overrideBrowserWindowOptions: {
@@ -102,10 +99,6 @@ function createWindow() {
         parent: mainWindow,
         modal: false,
         show: true,
-        webPreferences: {
-          ...windowOptions.webPreferences,
-          userAgent: customUA,
-        },
       },
     };
   });
@@ -120,7 +113,10 @@ function createWindow() {
   mainWindow.loadURL(appConfig.homepageURL);
 }
 
-app.whenReady().then(createWindow);
+app.whenReady().then(() => {
+  app.userAgentFallback = `${session.defaultSession.getUserAgent()} ${CUSTOM_USER_AGENT}`;
+  createWindow();
+});
 
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') app.quit();


### PR DESCRIPTION
- Child windows did not use the custom user agent during their initial page load, which caused requests from those windows to miss the expected user agent.
- This happened because the custom user agent was applied after the child window had already started loading.
- This is fixed by ensuring child windows use the custom user agent from the moment they are created.

Todo - https://app.basecamp.com/4160028/buckets/47506127/card_tables/cards/10041683279