### PR TITLE
fix: Ensure Electron binaries are reinstalled after dependency install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "testpress_desktop_application",
       "version": "1.0.1",
+      "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
         "electron-squirrel-startup": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "main": "dist/main.js",
   "scripts": {
     "build": "tsc",
+    "postinstall": "node scripts/reinstall-electron.cjs",
     "start": "npm run build && electron .",
     "dist": "npm run build && electron-builder",
     "dist:mac-arm": "npm run build && electron-builder --config electron-builder.config.cjs --mac --arm64",

--- a/scripts/reinstall-electron.cjs
+++ b/scripts/reinstall-electron.cjs
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+let electronDir;
+try {
+  electronDir = path.dirname(require.resolve('electron/package.json'));
+} catch (e) {}
+
+if (electronDir && fs.existsSync(electronDir)) {
+  const distDir = path.join(electronDir, 'dist');
+  fs.rmSync(distDir, { recursive: true, force: true });
+
+  const res = spawnSync(process.execPath, ['install.js'], {
+    cwd: electronDir,
+    stdio: 'inherit',
+  });
+
+  if (res.error) {
+    console.error(res.error);
+    process.exit(1);
+  }
+
+  if (res.status !== 0) {
+    process.exit(res.status || 1);
+  }
+}


### PR DESCRIPTION
- Electron installations could reuse stale or incomplete binaries from a previous install, leading to build or runtime failures.
- This happened because existing Electron binaries were not always refreshed during dependency installation.
- This is fixed by re-running Electron's installation step after removing the existing binaries, ensuring a clean and consistent installation every time.